### PR TITLE
[Issue:37] : Fixing dark mode for all pages

### DIFF
--- a/about.css
+++ b/about.css
@@ -155,6 +155,11 @@ body.dark h1 {
   padding-right: 100px;
 }
 
+body.dark .header-about .heading {
+  background-color: #000;
+  color: white;
+}
+
 .Mid {
   display: flex;
   /* padding: -10px; */
@@ -176,6 +181,10 @@ body.dark h1 {
   background-position: right;
 }
 
+body.dark .Mid * { 
+  background-color: #000;
+  color: white;
+}
 
 .top{
   background-color: #f2f2f2;
@@ -474,6 +483,10 @@ body.dark h1 {
   transition: .8s .2s;
 }
 
+body.dark .top *, body.dark .top { 
+  background-color: #000;
+  color: white;
+}
 
 /* Footer */
 
@@ -514,7 +527,10 @@ body.dark h1 {
   padding-right: 1.9rem;
 }
 
-
+body.dark .footer {
+  background: #2678cf26;
+  color: white;
+}
 
 /*
 iPad and Surface

--- a/brands.css
+++ b/brands.css
@@ -345,6 +345,14 @@ body.dark h1 {
     padding-right: 1.9rem;
   }
 
+  body.dark .footer {
+    background: #2678cf26;
+    color: white;
+  }
+
+  body.dark .footer .box-container .box * {
+    color: white;
+  }
  
 @media (max-width:991px){
 

--- a/brands.css
+++ b/brands.css
@@ -289,26 +289,7 @@ body.dark h1 {
   border-radius: 10px;
 }
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+/* Styling for footer */
 
 .footer {
     background: #ffe3de;

--- a/contact.css
+++ b/contact.css
@@ -256,7 +256,7 @@ body.dark .header-about .heading {
   text-align: center;
   border-radius: 0.5rem;
   width: 300px;
-  background-color: #f2f2f2;
+  background-color: transparent;
   padding-top: 30px;
   padding-bottom: 27px;
 }
@@ -265,6 +265,10 @@ body.dark .header-about .heading {
   font-size: 37px;
   color: #ffc72c;
   padding-bottom: 25px;
+}
+
+body.dark .contact .row form h3 {
+  color: white;
 }
 
 .contact .row form .box {
@@ -288,6 +292,14 @@ body.dark .header-about .heading {
 
 .contact .row form .glow-on-hover {
   font-size: 23px;
+}
+
+body.dark .contact .row form .glow-on-hover:after {
+  background-color: white;
+  background: white;
+}
+body.dark .contact .row form .glow-on-hover{
+  color: black;
 }
 
 .map {

--- a/contact.css
+++ b/contact.css
@@ -236,6 +236,11 @@ body.dark h1 {
   padding-bottom: 70px;
 }
 
+body.dark .header-about .heading {
+  background-color: black;
+  color: white;
+}
+
 .contact .row {
   padding: 40px;
   display: flex;
@@ -373,6 +378,10 @@ body.dark h1 {
   padding-right: 1.9rem;
 }
 
+body.dark .footer {
+  background: #2678cf26;
+  color: white;
+}
 
 
 @media (max-width:991px){

--- a/customs.css
+++ b/customs.css
@@ -29,6 +29,7 @@ body.dark {
 }
 
 body.dark h1 {
+  background-color: #000;
   color: white;
 }
 
@@ -323,7 +324,10 @@ color:red;
   padding-right: 1.9rem;
 }
 
-
+body.dark .footer {
+  background: #2678cf26;
+  color: white;
+}
 
 
 @media (max-width:991px){


### PR DESCRIPTION
Issue - https://github.com/vedantmistryy/vedantmistryy.github.io/issues/37
Fixed Dark Mode view for all pages below -

1. About Page
<img width="1439" alt="Screenshot 2022-10-02 at 11 12 29 PM" src="https://user-images.githubusercontent.com/96312216/193468218-a48b0818-3401-4d87-974d-27dfc8b64685.png">
<img width="1434" alt="Screenshot 2022-10-02 at 11 11 55 PM" src="https://user-images.githubusercontent.com/96312216/193468193-a23201c9-cc9d-432d-8e54-c588eb0c65c1.png">


2. Brands Page
<img width="1433" alt="Screenshot 2022-10-02 at 11 12 55 PM" src="https://user-images.githubusercontent.com/96312216/193468232-06985a2c-a675-481f-b246-e9a2f8eb1115.png">


3. Customs Page
<img width="1438" alt="Screenshot 2022-10-02 at 11 13 15 PM" src="https://user-images.githubusercontent.com/96312216/193468241-8a5fced2-f6d5-4208-afa4-056855e0477e.png">


4. Contact Page
<img width="1426" alt="Screenshot 2022-10-02 at 11 13 45 PM" src="https://user-images.githubusercontent.com/96312216/193468259-c5e1583e-d91f-48a5-bcfc-49670269d41c.png">
<img width="1432" alt="Screenshot 2022-10-02 at 11 14 04 PM" src="https://user-images.githubusercontent.com/96312216/193468271-cdb2d771-3a8d-4c63-a3ef-9b6aa11f0f23.png">
